### PR TITLE
Remove imghdr dependency for image file type recognition to support Python 3.13+

### DIFF
--- a/email_sender.py
+++ b/email_sender.py
@@ -1,7 +1,6 @@
 from email.message import EmailMessage
 from os import environ
 
-import imghdr
 import smtplib
 
 sender_mail = environ['SENDER_MAIL']
@@ -25,7 +24,7 @@ def add_image(msg: EmailMessage, file_name):
     try:
         with open(file_name, 'rb') as f:
             img_data = f.read()
-            img_type = imghdr.what(f.name)
+            img_type = f.name.split('.')[-1]
             img_name = f.name
 
             msg.add_attachment(img_data, maintype='image', subtype=img_type, filename=img_name)


### PR DESCRIPTION
Image attachment for emails no longer relies on imghdr for finding a file's extension, but instead uses the primitive string split() method and indexing to identify that information.